### PR TITLE
Consistent Cerebro directory name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN cd /opt/ \
     && wget -O cerebro-${CEREBRO_VERSION}.tgz https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz \
     && tar zxvf cerebro-${CEREBRO_VERSION}.tgz \
     && rm cerebro-${CEREBRO_VERSION}.tgz \
-    && mkdir cerebro-${CEREBRO_VERSION}/logs
+    && mkdir cerebro-${CEREBRO_VERSION}/logs \
+    && mv cerebro-${CEREBRO_VERSION} cerebro
 
-WORKDIR /opt/cerebro-${CEREBRO_VERSION}
+WORKDIR /opt/cerebro
 EXPOSE 9000
 CMD ["./bin/cerebro"]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Then you can access the web console in this URL: http://[Docker_Host]:9000
 
 You can mount volumes for the configuration folder and / the logs, for example:
 
-`docker run -d -p 9000:9000 --name cerebro -v /mount_folder/logs:/opt/cerebro-0.5.0/logs -v /mount_folder/conf:/opt/cerebro-0.5.0/conf yannart/cerebro:latest`
+`docker run -d -p 9000:9000 --name cerebro -v /mount_folder/logs:/opt/cerebro/logs -v /mount_folder/conf:/opt/cerebro/conf yannart/cerebro:latest`
 
-Where `/mount_folder` is a folder in the Docker host to contain the data. If mounted, the volume `/opt/cerebro-0.5.0/conf` must contain a valid configuration.
+Where `/mount_folder` is a folder in the Docker host to contain the data. If mounted, the volume `/opt/cerebro/conf` must contain a valid configuration.
 
 ## Docker-compose example
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   # Elasticsearch cluster
   elasticsearch:
-    image: elasticsearch:5.1.1
+    image: elasticsearch:5-alpine
     command: -E node.name="es1" -E discovery.zen.ping.unicast.hosts="elasticsearch2:9300"
     environment:
       ES_JAVA_OPTS: -Xms750m -Xmx750m
@@ -26,7 +26,7 @@ services:
       - app_net
 
   elasticsearch2:
-    image: elasticsearch:5.1.1
+    image: elasticsearch:5-alpine
     command: -E node.name="es2" -E discovery.zen.ping.unicast.hosts="elasticsearch:9300"
     environment:
       ES_JAVA_OPTS: -Xms750m -Xmx750m


### PR DESCRIPTION
* Removed version from Cerebro directory name. It is useful when binding config-file to container in Compose or in scripts. No need to change path with every version update.
* Updated README to reflect this change.
* Also updated compose file with new alpine images of Elasticsearch to reduce resources and time needed to get example up and running.