### PR TITLE
remove RUNNING_PID before start cerebro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN cd /opt/ \
 
 WORKDIR /opt/cerebro
 EXPOSE 9000
-CMD ["./bin/cerebro"]
+CMD ["rm -rf ./RUNNING_PID && ./bin/cerebro"]


### PR DESCRIPTION
In case the docker process or the container is shutdown abnormally.